### PR TITLE
Make PYTHONPATH update work cross-platform

### DIFF
--- a/pythonloc/pythonloc.py
+++ b/pythonloc/pythonloc.py
@@ -26,8 +26,9 @@ def get_pypackages_lib_path(script_path=None):
 
 def get_env(script_path=None):
     env = dict(os.environ)
-    env["PYTHONPATH"] = (
-        ".:" + get_pypackages_lib_path(script_path) + ":" + env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = os.path.pathsep.join(
+        [".", get_pypackages_lib_path(script_path)]
+        + os.getenv("PYTHONPATH", "").split(os.path.pathsep)
     )
     return env
 


### PR DESCRIPTION
`os.path.pathsep` is `:` on POSIX-like platforms and `;` on Windows, so use that when adding paths to the `PYTHONPATH` variable.
`os.getenv` does (correct) case-insensitive lookup, but `env` here will be case-sensitive. Read existing value from `os.getenv` instead.