### PR TITLE
Fix broken homepage url on PyPI project page

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     description="Run Python using packages from local directory __pypackages__",
     long_description=README,
     long_description_content_type="text/markdown",
-    url="https://github.com/pipxproject/pythonloc",
+    url="https://github.com/cs01/pythonloc",
     packages=find_packages(exclude=["contrib", "docs", "tests*"]),
     include_package_data=True,
     keywords=[],


### PR DESCRIPTION
If you go to the [pythonloc project page on PyPI](https://pypi.org/project/pythonloc/) then try to click "Homepage", you'll get a 404.

This PR changes the homepage URL to https://github.com/cs01/pythonloc.